### PR TITLE
ci: add dependency commit prefix support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,5 +7,7 @@ version: 2
 updates:
   - package-ecosystem: "gradle" # See documentation for possible values
     directory: "/" # Location of package manifests
+    commit-message:
+      prefix: "dependency"
     schedule:
       interval: "weekly"

--- a/.github/workflows/commit-message.yml
+++ b/.github/workflows/commit-message.yml
@@ -17,7 +17,7 @@ jobs:
           BASE="${{ github.event.pull_request.base.sha }}"
           HEAD="${{ github.event.pull_request.head.sha }}"
 
-          PATTERN='^(Issue #[0-9]+|minor|doc|infra|ci): .+'
+          PATTERN='^(Issue #[0-9]+|minor|doc|dependency|infra|ci): .+'
           MAX_LENGTH=72
 
           FAILED=0
@@ -44,7 +44,7 @@ jobs:
           if [ "$FAILED" -eq 1 ]; then
             echo ""
             echo "Each commit message must:"
-            echo "  - Start with one of: Issue #123: / minor: / doc: / infra: / ci:"
+            echo "  - Start with one of: Issue #123: / minor: / doc: / dependency: / infra: / ci:"
             echo "  - Be at most $MAX_LENGTH characters"
             exit 1
           fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,7 @@ Every commit message subject line must:
   - `Issue #123:` — work tracked by an issue
   - `minor:` — small change not worth an issue
   - `doc:` — documentation-only change
+  - `dependency:` — dependency or version update
   - `infra:` — infrastructure or tooling change
   - `ci:` — CI/CD change
 - Be at most **72 characters** (enforced by the `commit-message` CI workflow)


### PR DESCRIPTION
## Summary
- add the dependency: commit prefix to project guidance
- allow the new prefix in the commit message CI check
- configure Dependabot to use the new prefix for Gradle updates